### PR TITLE
Dockerfile for GOSINT

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,51 @@
+#
+# GOSINT Dockerfile
+#
+# https://github.com/ciscocsirt/GOSINT
+#
+# Written by: Jason Soto @jsitech
+# 
+# Usage:
+#
+#   sudo docker build -t gosint .
+#   sudo docker run -it -p 443:443 gosint
+
+
+FROM golang:1.8
+
+#Install Dependencies
+
+RUN apt-get update && \
+    apt-get -y install wget nginx mongodb php5-fpm nginx git
+
+# Create SSL Certs for Nginx
+RUN mkdir /etc/nginx/ssl \
+    && openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/nginx/ssl/nginx.key -out /etc/nginx/ssl/nginx.crt -subj "/C=US/ST=NY/L=NY/O=IT/OU=IT/CN=ssl.gosint"
+
+#Add config file for nginx
+ADD default.conf /etc/nginx/sites-available/default
+
+RUN go get github.com/tools/godep \ 
+    && go install github.com/tools/godep
+
+WORKDIR /go/src/
+
+#Clone GOSINT Repository
+
+RUN git clone https://github.com/ciscocsirt/GOSINT
+
+WORKDIR /go/src/GOSINT/
+
+COPY gosint.sh gosint.sh
+RUN chmod 655 gosint.sh
+
+RUN go build -o gosint \
+    && chmod +x gosint
+
+RUN mkdir /var/www/gosint \
+    && cp -r website/* /var/www/gosint/ \
+    && chown -R www-data:www-data /var/www/gosint/
+
+#start gosint
+
+CMD ["./gosint.sh"]

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,28 @@
+### GOSINT - Open Source Threat Intelligence Gathering and Processing Framework
+=====================================
+
+If you want to sidestep the process of installing and configuring all requirements to run GOSINT, follow the instructions to run GOSINT on a Docker Container.
+
+
+***Creating the Docker Image***
+=========================
+```
+docker build -t gosint .
+```
+
+This will take a little, but at the end we will have and image with the tag gosint.
+
+***Running the Container***
+=========================
+```
+docker run -i -t -p 443:443 gosint
+```
+
+***Set Volume for Persistent Data***
+=========================
+```
+docker run -i -t -p 443:443 -v /your/persistent/data/path:/var/lib/mongodb gosint
+```
+
+
+

--- a/Docker/default.conf
+++ b/Docker/default.conf
@@ -1,0 +1,57 @@
+server {
+    ssl_certificate /etc/nginx/ssl/nginx.crt;
+    ssl_certificate_key /etc/nginx/ssl/nginx.key;
+    listen 443 ssl;
+
+    root /var/www/gosint;
+    index index.php index.html index.htm;
+    try_files $uri $uri/ @apachesite;
+
+    server_name localhost;
+
+    gzip on;
+    gzip_proxied any;
+    gzip_types
+        text/css
+        text/javascript
+        text/xml
+        text/plain
+        application/javascript
+        application/x-javascript
+        application/json;
+
+    #location / {
+    #    try_files $uri $uri/ =404;
+    #}
+
+    error_page 404 /404.html;
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
+
+    location @apachesite {
+        auth_basic           "closed site";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        add_header Front-End-Https on;
+        proxy_redirect off;
+    }
+
+    location ~ \.php$ {
+        auth_basic           "closed site";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+ #       fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+        fastcgi_pass unix:/run/php5-fpm.sock;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+}

--- a/Docker/gosint.sh
+++ b/Docker/gosint.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+#Start Service
+
+/etc/init.d/nginx start
+/etc/init.d/mongodb start
+/etc/init.d/php5-fpm start
+
+#create user for UI Access
+
+touch /etc/nginx/.htpasswd
+
+echo -e "We will now create Credentials to access the Gosint UI"
+
+echo -n "Type a username: "; read username
+echo -n "Type a Password: "; read password
+
+echo $username:$(openssl passwd -crypt $password) >> /etc/nginx/.htpasswd
+
+#run Gosint
+
+/go/src/GOSINT/gosint


### PR DESCRIPTION
Dockerfile to run GOSINT on a Docker Container. Makes more sense to have it on the GOSINT Repo. This way users will always have the latest version when they create the Docker image as opposed to the hub image which needs to be updated manually.